### PR TITLE
Use containers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -96,7 +96,7 @@ IndentCaseLabels: false
 IndentExternBlock: NoIndent
 IndentGotoLabels: false
 IndentPPDirectives: None
-IndentRequiresClause: false
+IndentRequiresClause: true
 IndentWidth: 2
 IndentWrappedFunctionNames: false
 InsertBraces: true

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   formatting-check:
     name: Formatting check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -16,53 +16,32 @@ jobs:
           pushd $GITHUB_WORKSPACE
           ci-extra/check-lines.sh
           popd
-      - name: Run clang-format style check for C/C++/Protobuf programs.
-        uses: jidicula/clang-format-action@v4.9.0
+      - name: Run clang-format style check
+        # TODO format using clang container
+        uses: jidicula/clang-format-action@v4.11.0
         with:
-          clang-format-version: '15'
+          clang-format-version: '16'
           check-path: '.'
 
   test:
     needs: formatting-check
-    name: Tests in ${{ matrix.build_type }} with ${{ matrix.compilerSetter }}
-    runs-on: ubuntu-22.04
-    container:
-      image: ubuntu:22.04
-      options: --privileged
-    env:
-      DEBIAN_FRONTEND: noninteractive
+    name: Tests in ${{ matrix.build_type }} with ${{ matrix.compiler }}
+
     strategy:
+      fail-fast: false
       matrix:
         build_type: [Release, Debug, SanitizedDebug, RelWithDebInfo]
-        # clang-15 uses dwarf-5 which valgrind doesn't support yet
-        compilerSetter: [
-          CC=gcc-12 CXX=g++-12,
-          CC=clang-15 CXX='clang++-15 -gdwarf-4 -stdlib=libc++' ASAN_OPTIONS=alloc_dealloc_mismatch=0
-        ]
+        compiler: ['gcc:13', 'clang:16']
+
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/cpp-kt/${{ matrix.compiler }}
+
     defaults:
       run:
         shell: bash
 
     steps:
-      - name: Setup dependencies
-        run: |
-          apt-get update
-          apt-get install -y gpg wget
-          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
-            | gpg --dearmor - \
-            | tee /usr/share/keyrings/kitware-archive-keyring.gpg \
-            >/dev/null
-          echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' \
-            | tee /etc/apt/sources.list.d/kitware.list >/dev/null
-
-          apt-get update
-          apt-get install -y git build-essential binutils g++-12 gcc-12 clang-15 cmake valgrind libc++-15-dev libc++abi-15-dev \
-            ninja-build curl zip unzip tar pkg-config kitware-archive-keyring gdb
-          cd ..
-          git clone https://github.com/microsoft/vcpkg.git
-          ./vcpkg/bootstrap-vcpkg.sh
-          cd $GITHUB_WORKSPACE
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -87,7 +66,7 @@ jobs:
           fi
 
       - name: Build main
-        run: ${{ matrix.compilerSetter }} ci-extra/build.sh ${{ matrix.build_type }}
+        run: ci-extra/build.sh ${{ matrix.build_type }}
 
       - name: Test main
         run: |
@@ -95,8 +74,12 @@ jobs:
             echo -ne '\e[0;33mWARNING: Tests were not updated on your side. '
             echo -e 'This script will however run the most recent version.\e[0m'
           fi
-          ${{ matrix.compilerSetter }} ci-extra/test.sh ${{ matrix.build_type }}
+          if [[ ${{ matrix.build_type }} == "SanitizedDebug" ]]; then
+            ASAN_OPTIONS=alloc_dealloc_mismatch=0 ci-extra/test.sh ${{ matrix.build_type }}
+          else
+            ci-extra/test.sh ${{ matrix.build_type }}
+          fi
 
       - if: ${{ matrix.build_type == 'RelWithDebInfo' }}
         name: Test main with valgrind
-        run: ${{ matrix.compilerSetter }} ci-extra/test-valgrind.sh
+        run: ci-extra/test-valgrind.sh

--- a/ci-extra/build.sh
+++ b/ci-extra/build.sh
@@ -4,6 +4,6 @@ IFS=$' \t\n'
 
 mkdir -p cmake-build-$1
 rm -rf cmake-build-$1/*
-cmake "-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake" -GNinja --preset $1 \
+cmake "-DCMAKE_TOOLCHAIN_FILE=/opt/vcpkg/scripts/buildsystems/vcpkg.cmake" --preset $1 \
   -DENABLE_SLOW_TEST=ON -DTREAT_WARNINGS_AS_ERRORS=ON -S .
 cmake --build cmake-build-$1

--- a/ci-extra/check-lines.sh
+++ b/ci-extra/check-lines.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ou pipefail
 
 exit_code=0
 

--- a/ci-extra/set-upstream.sh
+++ b/ci-extra/set-upstream.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+set -eou pipefail
 
 UPSTREAM_REPO=CPP-KT/template-task

--- a/test/dummy_test.cpp
+++ b/test/dummy_test.cpp
@@ -4,6 +4,6 @@
 
 #include <stdexcept>
 
-TEST(dummy_test, test_abi) {
+TEST(dummy_test, abi) {
   EXPECT_THROW(throwing_func(), std::logic_error);
 }


### PR DESCRIPTION
В CI теперь используются контейнеры, сгенерированные [CPP-KT/containers](https://github.com/CPP-KT/containers) (публикуются они [сюда](https://github.com/orgs/CPP-KT/packages)). За счёт этого не тратится при каждом прогоне время на установку необходимых зависимостей, в т.ч. сборку `valgrind` (как предложено в #21) и `gtest`. Выигрыш по времени достигает полутора минут.

Скрипт создания контейнеров достаточно универсален, чтобы иметь возможность быстро перейти на новую версию компилятора. На данный момент генерируются контейнеры для `gcc-12`, `gcc-13`, `clang-15`, `clang-16` и `clang-17`. В `workflow/cpp.yml` в матрице указывается, какие из контейнеров надо использовать.

В то же время, `clang-format` на данный момент запускается через `jidicula/clang-format-action`, а не в одном из наших контейнеров, но это можно в будущем поменять.

Помимо прочего, возможность использовать компиляторы разных версий позволит проверять, компилируются ли отдельные части заданий (преимущественно, тесты) на более старых версиях компиляторов, которые могут быть установлены на устройствах студентов.